### PR TITLE
Compile TCL only if installed version is older than 8.6.5 (refs #25298)

### DIFF
--- a/BUILD/install_build_deps.sh
+++ b/BUILD/install_build_deps.sh
@@ -153,23 +153,26 @@ sudo make install
 cd ../../
 
 # TCL
-mkdir tcl
-cd tcl
-wget -q --no-check-certificate http://prdownloads.sourceforge.net/tcl/tcl8.6.5-src.tar.gz
-
-if [ $? != 0 ]
+tcl_version=$(tclsh <<< 'puts [info patchlevel]')
+if [[ "$tcl_version" < "8.6.5" ]]
 then
-    echo "Error getting tcl"
-    sudo rm -rf $tmpdir
-    exit 1
+    mkdir tcl
+    cd tcl
+    wget -q --no-check-certificate http://prdownloads.sourceforge.net/tcl/tcl8.6.5-src.tar.gz
+
+    if [ $? != 0 ]
+    then
+        echo "Error getting tcl"
+        sudo rm -rf $tmpdir
+        exit 1
+    fi
+
+    tar xzf tcl8.6.5-src.tar.gz
+    cd tcl8.6.5/unix
+    ./configure
+    sudo make install
+    cd ../../..
 fi
-
-tar xzf tcl8.6.5-src.tar.gz
-cd tcl8.6.5/unix
-./configure
-sudo make install
-cd ../../..
-
 
 # Jansson
 git clone https://github.com/akheron/jansson.git


### PR DESCRIPTION
I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
